### PR TITLE
Some improvements

### DIFF
--- a/index-wp-redis.php
+++ b/index-wp-redis.php
@@ -9,11 +9,15 @@ function getMicroTime($t)
     return ((float) $usec + (float) $sec);
 }
 
-$seconds_cache_redis = 60 * 60 * 12; // 12 hours by default, you can change in this in wp-admin options page
-$ip_of_your_website  = '127.0.0.1'; //You must set this to the IP of your website
-$secret_string       = "changeme";
+// 12 hours by default, you can change in this in wp-admin options page
+$seconds_cache_redis = 60 * 60 * 12;
+
+//You must set this to the IP of your website
+$ip_of_your_website  = '127.0.0.1'; 
+
 /*This is if you want to manually refresh the cache
 ex: http://example.com/sample-post?refresh=changeme    */
+$secret_string       = "changeme";
 
 // so we don't confuse the cloudflare server 
 if (isset($_SERVER['HTTP_CF_CONNECTING_IP'])) {
@@ -21,9 +25,7 @@ if (isset($_SERVER['HTTP_CF_CONNECTING_IP'])) {
 }
 
 define('WP_USE_THEMES', true);
-$current_url = "http://" . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
-$current_url = str_replace("?refresh=$secret_string", '', $current_url); //clean up the URL
-$current_url = str_replace("&refresh=$secret_string", '', $current_url);
+$current_url = str_replace(array("?refresh=${secret_string}","&refresh=${secret_string}"), '', "http://${_SERVER['HTTP_HOST']}${_SERVER['REQUEST_URI']}"); //clean up the URL
 $redis_key = md5($current_url);
 
 try {
@@ -31,8 +33,7 @@ try {
     if (class_exists('Redis')) {
         $redis = new Redis();
         
-        // Sockets can be used as well '/tmp/redis.sock'
-        // documentation can be found at https://github.com/nicolasff/phpredis/#connection
+        // Sockets can be used as well. Documentation @ https://github.com/nicolasff/phpredis/#connection
         $redis->connect('127.0.0.1');
         
     } else // Fallback to predis5.2.php
@@ -40,55 +41,55 @@ try {
         include("wp-content/plugins/wp-redis-cache/predis5.2.php"); //we need this to use Redis inside of PHP
         $redis = new Predis_Client();
     }
-} catch (Exception $e) {
-    $redisError=true;
-}
-
-//Either manual refresh cache by adding ?refresh=secret_string after the URL or somebody posting a comment
-if (!isset($redisError) && (isset($_GET['refresh']) || $_GET['refresh'] == $secret_string || ($_SERVER['HTTP_REFERER'] == $current_url && $_SERVER['REQUEST_URI'] != '/' && $_SERVER['REMOTE_ADDR'] != $ip_of_your_website))) {
     
-    $redis->del($redis_key);
-    require('./wp-blog-header.php');
-    
-    // This page is cached, lets display it
-} else if ($redis->exists($redis_key)) {
-    $html_of_page = $redis->get($redis_key);
-    echo $html_of_page;
-    
-    // If the cache does not exist lets display the user the normal page without cache, and then fetch a new cache page
-} else if ($_SERVER['REMOTE_ADDR'] != $ip_of_your_website && strstr($current_url, 'preview=true') == false) {
-    
-    $isPOST = ($_SERVER['REQUEST_METHOD'] === 'POST') ? 1 : 0;
-    
-    $loggedIn = preg_match("/wordpress_logged_in/", var_export($_COOKIE, true));
-    if ($isPost == 0 && $loggedIn == 0) {
-        ob_start();
+    //Either manual refresh cache by adding ?refresh=secret_string after the URL or somebody posting a comment
+    if (isset($_GET['refresh']) || $_GET['refresh'] == $secret_string || strpos($_SERVER['REQUEST_URI'],"refresh=${secret_string}")!==false || ($_SERVER['HTTP_REFERER'] == $current_url && $_SERVER['REQUEST_URI'] != '/' && $_SERVER['REMOTE_ADDR'] != $ip_of_your_website)) {
+        
+        $redis->del($redis_key);
         require('./wp-blog-header.php');
-        $html_of_page = ob_get_contents();
-        ob_end_clean();
+        
+    // This page is cached, lets display it
+    } else if ($redis->exists($redis_key)) {
+        $html_of_page = $redis->get($redis_key);
         echo $html_of_page;
         
-        $usr_seconds = get_option('wp-redis-cache-seconds'); //if the user has the seconds defined in the admin section use it
-        if (isset($usr_seconds) && is_numeric($usr_seconds)) {
-            $seconds_cache_redis = $usr_seconds;
+     // If the cache does not exist lets display the user the normal page without cache, and then fetch a new cache page
+    } else if ($_SERVER['REMOTE_ADDR'] != $ip_of_your_website && strstr($current_url, 'preview=true') == false) {
+        
+        $isPOST = ($_SERVER['REQUEST_METHOD'] === 'POST') ? 1 : 0;
+        
+        $loggedIn = preg_match("/wordpress_logged_in/", var_export($_COOKIE, true));
+        if ($isPost == 0 && $loggedIn == 0) {
+            ob_start();
+            require('./wp-blog-header.php');
+            $html_of_page = ob_get_contents();
+            ob_end_clean();
+            echo $html_of_page;
+            
+			//if the user has the seconds defined in the admin section use it
+            $usr_seconds = get_option('wp-redis-cache-seconds');
+            if (isset($usr_seconds) && is_numeric($usr_seconds)) {
+                $seconds_cache_redis = $usr_seconds;
+            }
+			
+			// When a page displays after an "HTTP 404: Not Found" error occurs, do not cache
+            if (!is_404()) {
+                $redis->setex($redis_key, $seconds_cache_redis, $html_of_page);
+            }
+        } else //either the user is logged in, or is posting a comment, show them uncached
+            {
+            require('./wp-blog-header.php');
         }
         
-        if (strlen($html_of_page) > 5000) {   //prevents caching error pages 
-            $redis->setex($redis_key, $seconds_cache_redis, $html_of_page);
-        }
-    } else //either the user is logged in, or is posting a comment, show them uncached
-        {
+    } else if ($_SERVER['REMOTE_ADDR'] != $ip_of_your_website && strstr($current_url, 'preview=true') == true) {
         require('./wp-blog-header.php');
     }
-    
-} else if (($_SERVER['REMOTE_ADDR'] != $ip_of_your_website && strstr($current_url, 'preview=true') == true) || isset($redisError)) {
+     // else {   // This is what your server should get if no cache exists  //depricated, as the ob_start() is cleaner
+        // require('./wp-blog-header.php');
+    // }
+} catch (Exception $e) {
     require('./wp-blog-header.php');
 }
- // else {   // This is what your server should get if no cache exists  //depricated, as the ob_start() is cleaner
-    // require('./wp-blog-header.php');
-// }
-
-
 
 if ($_SERVER['REMOTE_ADDR'] != $ip_of_your_website) {
     // How long did it take to load the page? (CloudFlare may strip out comments)


### PR DESCRIPTION
- My previous try/catch did not get all exceptions. This code does.
- $current_url is definde in one line
- Speaking URLs can now be used with cache cleaning: domain.tld/nice/url/?refresh=changeme 
- !is_404(); instead of strlen($html_of_page) > 5000
