### PR TITLE
Whitespace in header and admin page capabilities fixes.

### DIFF
--- a/wp-redis-cache/cache.php
+++ b/wp-redis-cache/cache.php
@@ -72,5 +72,3 @@ jQuery(document).ready(function($) {
 </script>
 <?php 
 }
-?>
-

--- a/wp-redis-cache/options.php
+++ b/wp-redis-cache/options.php
@@ -29,7 +29,7 @@ Author URI: http://dudelol.com
 add_action('admin_menu', 'add_redis_interface');
 
 function add_redis_interface() {
-    add_options_page('Wp Redis Cache', 'Wp Redis Cache', '8', 'functions', 'edit_redis_options');
+    add_options_page('Wp Redis Cache', 'Wp Redis Cache', 'manage_options', 'functions', 'edit_redis_options');
 }
 
 function edit_redis_options() {


### PR DESCRIPTION
Fix to stop plugin from creating extra whitespace (created issues with
zip file exports in Updraft Plus and Revolution Slider)
Fix to capabilities on the add_options_page call - set to manage_options
instead of level 8, levels have been deprecated.