### PR TITLE
Change HTTP Request Status in case of exception

### DIFF
--- a/index-wp-redis.php
+++ b/index-wp-redis.php
@@ -155,6 +155,7 @@ try {
     // }
 } catch (Exception $e) {
     //require( $wp_blog_header_path );
+    http_response_code(500);
     echo "Something went wrong: " . $e->getMessage();
 }
 


### PR DESCRIPTION
When using auto scaling technology, if something goes wrong, they detect it by sensing the HTTP Status. By setting up a 500 Status Code, the verification tool will not get fooled thinking everything is okay when clearly it is not.